### PR TITLE
Fix redirects

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -2,6 +2,7 @@
 / https://github.com/ocwg/spec/blob/main/spec/0.3/spec.md 302
 
 # Version-specific spec and schema files
+/:version https://github.com/ocwg/spec/blob/main/spec/:version/spec.md 301
 /:version/spec.md https://github.com/ocwg/spec/blob/main/spec/:version/spec.md 301
 /:version/schema.json https://github.com/ocwg/spec/blob/main/spec/:version/schema.json 301
 /:version/extensions.md https://github.com/ocwg/spec/blob/main/spec/:version/extensions.md 301

--- a/spec/0.3/spec.md
+++ b/spec/0.3/spec.md
@@ -1226,9 +1226,9 @@ A circle has a port at the geometric "top" position.
 - `https://spec.canvasprotocol.org/0.3/schema.json` - General OCIF JSON schema
 
 - Extension URIs (some selected exemplars):
-  - `https://spec.canvasprotocol.org/0.3/core/node-rect.json` - URI for the rectangle node extension
-  - `https://spec.canvasprotocol.org/0.3/core/rel-edge.json` - URI for the rectangle relation extension (core)
-  - `https://spec.canvasprotocol.org/0.3/extensions/node-ports.json` - The _ports_ extension schema for nodes in version 0.3; this is also its [URI](#uri)
+  - `https://spec.canvasprotocol.org/0.3/core/rect-node.json` - URI for the rectangle node extension
+  - `https://spec.canvasprotocol.org/0.3/core/edge-rel.json` - URI for the rectangle relation extension (core)
+  - `https://spec.canvasprotocol.org/0.3/extensions/ports-node.json` - The _ports_ extension schema for nodes in version 0.3; this is also its [URI](#uri)
 
 ## Changes
 


### PR DESCRIPTION
- Added a redirect for `https://spec.canvasprotocol.org/{version}`
- Links in the spec reverse the name and the type: fixed